### PR TITLE
Fix Get-AZAccessToken

### DIFF
--- a/AzureCommonStuff/AzureCommonStuff.psm1
+++ b/AzureCommonStuff/AzureCommonStuff.psm1
@@ -66,7 +66,7 @@ function Connect-AzAccount2 {
     )
 
     #region checks
-    $azAccesstoken = Get-AzAccessToken -ErrorAction SilentlyContinue
+    $azAccesstoken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue
 
     #region check whether there is valid existing session
     $tenantIsDomainName = $false

--- a/AzureCommonStuff_source/Connect-AzAccount2.ps1
+++ b/AzureCommonStuff_source/Connect-AzAccount2.ps1
@@ -67,7 +67,7 @@ function Connect-AzAccount2 {
     )
 
     #region checks
-    $azAccesstoken = Get-AzAccessToken -ErrorAction SilentlyContinue
+    $azAccesstoken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue
 
     #region check whether there is valid existing session
     $tenantIsDomainName = $false

--- a/AzureOtherStuff/AzureOtherStuff.psm1
+++ b/AzureOtherStuff/AzureOtherStuff.psm1
@@ -135,7 +135,7 @@ function Get-AzureAuditAggregatedSignInEvent {
     Get all 'Service principal sign-ins' events for selected enterprise app aggregated by 1 day.
 
     .NOTES
-    Token can be created using (Get-AzAccessToken -ResourceTypeName AadGraph).token.
+    Token can be created using (Get-AzAccessToken -AsSecureString -ResourceTypeName AadGraph).token.
     #>
 
     [CmdletBinding()]
@@ -173,11 +173,11 @@ function Get-AzureAuditAggregatedSignInEvent {
         [string] $aggregationWindow = '1d'
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
-    $accessToken = Get-AzAccessToken -ResourceUri 'https://graph.windows.net' -ErrorAction Stop
+    $accessToken = Get-AzAccessToken -AsSecureString -ResourceUri 'https://graph.windows.net' -ErrorAction Stop
 
     if (!$tenantId) {
         $tenantId = $accessToken.TenantId

--- a/AzureOtherStuff_source/Get-AzureAuditAggregatedSignInEvent.ps1
+++ b/AzureOtherStuff_source/Get-AzureAuditAggregatedSignInEvent.ps1
@@ -46,7 +46,7 @@ function Get-AzureAuditAggregatedSignInEvent {
     Get all 'Service principal sign-ins' events for selected enterprise app aggregated by 1 day.
 
     .NOTES
-    Token can be created using (Get-AzAccessToken -ResourceTypeName AadGraph).token.
+    Token can be created using (Get-AzAccessToken -AsSecureString -ResourceTypeName AadGraph).token.
     #>
 
     [CmdletBinding()]
@@ -84,11 +84,11 @@ function Get-AzureAuditAggregatedSignInEvent {
         [string] $aggregationWindow = '1d'
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
-    $accessToken = Get-AzAccessToken -ResourceUri 'https://graph.windows.net' -ErrorAction Stop
+    $accessToken = Get-AzAccessToken -AsSecureString -ResourceUri 'https://graph.windows.net' -ErrorAction Stop
 
     if (!$tenantId) {
         $tenantId = $accessToken.TenantId

--- a/AzureResourceStuff/AzureResourceStuff.psm1
+++ b/AzureResourceStuff/AzureResourceStuff.psm1
@@ -76,7 +76,7 @@ function Copy-AzureAutomationRuntime {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -266,7 +266,7 @@ function Export-VariableToStorage {
         [switch] $showProgress
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -339,7 +339,7 @@ function Get-AutomationVariable2 {
         [string] $name
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "Authentication needed. Please call 'Connect-AzAccount -Identity'."
     }
 
@@ -400,7 +400,7 @@ function Get-AzureAutomationRunbookRuntime {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -489,7 +489,7 @@ function Get-AzureAutomationRunbookTestJobOutput {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -586,7 +586,7 @@ function Get-AzureAutomationRunbookTestJobStatus {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -690,7 +690,7 @@ function Get-AzureAutomationRuntime {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -790,7 +790,7 @@ function Get-AzureAutomationRuntimeAvailableDefaultModule {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -915,7 +915,7 @@ function Get-AzureAutomationRuntimeCustomModule {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -996,7 +996,7 @@ function Get-AzureAutomationRuntimeSelectedDefaultModule {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -1062,7 +1062,7 @@ function Get-AzureResource {
         [switch] $selectCurrentSubscription
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -1179,7 +1179,7 @@ function Import-VariableFromStorage {
         [switch] $showProgress
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -1286,7 +1286,7 @@ function Invoke-AzureAutomationRunbookTestJob {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -1378,7 +1378,7 @@ function New-AzureAutomationGraphToken {
 
     #>
 
-    $accessToken = Get-AzAccessToken -ResourceUrl "https://management.azure.com" -ErrorAction Stop
+    $accessToken = Get-AzAccessToken -AsSecureString -ResourceUrl "https://management.azure.com" -ErrorAction Stop
     if ($accessToken.Token) {
         $header = @{
             'Content-Type'  = 'application/json'
@@ -1521,7 +1521,7 @@ function New-AzureAutomationModule {
         }
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -1953,7 +1953,7 @@ function New-AzureAutomationRuntime {
     }
     #endregion checks
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -2117,7 +2117,7 @@ function New-AzureAutomationRuntimeModule {
         }
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -2515,7 +2515,7 @@ function Remove-AzureAutomationRuntime {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -2619,7 +2619,7 @@ function Remove-AzureAutomationRuntimeModule {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -2702,7 +2702,7 @@ function Set-AutomationVariable2 {
         $value
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "Authentication needed. Please call 'Connect-AzAccount -Identity'."
     }
 
@@ -2767,7 +2767,7 @@ function Set-AzureAutomationRunbookRuntime {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -2933,7 +2933,7 @@ function Set-AzureAutomationRuntimeDefaultModule {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -3096,7 +3096,7 @@ function Set-AzureAutomationRuntimeDescription {
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -3161,7 +3161,7 @@ function Update-AzureAutomationModule {
         throw "Choose allModule or allCustomModule"
     }
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 
@@ -3362,7 +3362,7 @@ function Update-AzureAutomationRunbookModule {
         throw "Choose moduleName or allCustomModule"
     }
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Copy-AzureAutomationRuntime.ps1
+++ b/AzureResourceStuff_source/Copy-AzureAutomationRuntime.ps1
@@ -76,7 +76,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Export-VariableToStorage.ps1
+++ b/AzureResourceStuff_source/Export-VariableToStorage.ps1
@@ -101,7 +101,7 @@ function Export-VariableToStorage {
         [switch] $showProgress
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Get-AutomationVariable2.ps1
+++ b/AzureResourceStuff_source/Get-AutomationVariable2.ps1
@@ -32,7 +32,7 @@
         [string] $name
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "Authentication needed. Please call 'Connect-AzAccount -Identity'."
     }
 

--- a/AzureResourceStuff_source/Get-AzureAutomationRunbookRuntime.ps1
+++ b/AzureResourceStuff_source/Get-AzureAutomationRunbookRuntime.ps1
@@ -40,7 +40,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Get-AzureAutomationRunbookTestJobOutput.ps1
+++ b/AzureResourceStuff_source/Get-AzureAutomationRunbookTestJobOutput.ps1
@@ -60,7 +60,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Get-AzureAutomationRunbookTestJobStatus.ps1
+++ b/AzureResourceStuff_source/Get-AzureAutomationRunbookTestJobStatus.ps1
@@ -41,7 +41,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Get-AzureAutomationRuntime.ps1
+++ b/AzureResourceStuff_source/Get-AzureAutomationRuntime.ps1
@@ -75,7 +75,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Get-AzureAutomationRuntimeAvailableDefaultModule.ps1
+++ b/AzureResourceStuff_source/Get-AzureAutomationRuntimeAvailableDefaultModule.ps1
@@ -51,7 +51,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Get-AzureAutomationRuntimeCustomModule.ps1
+++ b/AzureResourceStuff_source/Get-AzureAutomationRuntimeCustomModule.ps1
@@ -67,7 +67,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Get-AzureAutomationRuntimeSelectedDefaultModule.ps1
+++ b/AzureResourceStuff_source/Get-AzureAutomationRuntimeSelectedDefaultModule.ps1
@@ -52,7 +52,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Get-AzureResource.ps1
+++ b/AzureResourceStuff_source/Get-AzureResource.ps1
@@ -38,7 +38,7 @@ function Get-AzureResource {
         [switch] $selectCurrentSubscription
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Import-VariableFromStorage.ps1
+++ b/AzureResourceStuff_source/Import-VariableFromStorage.ps1
@@ -72,7 +72,7 @@ function Import-VariableFromStorage {
         [switch] $showProgress
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Invoke-AzureAutomationRunbookTestJob.ps1
+++ b/AzureResourceStuff_source/Invoke-AzureAutomationRunbookTestJob.ps1
@@ -52,7 +52,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/New-AzureAutomationGraphToken.ps1
+++ b/AzureResourceStuff_source/New-AzureAutomationGraphToken.ps1
@@ -29,7 +29,7 @@ function New-AzureAutomationGraphToken {
 
     #>
 
-    $accessToken = Get-AzAccessToken -ResourceUrl "https://management.azure.com" -ErrorAction Stop
+    $accessToken = Get-AzAccessToken -AsSecureString -ResourceUrl "https://management.azure.com" -ErrorAction Stop
     if ($accessToken.Token) {
         $header = @{
             'Content-Type'  = 'application/json'

--- a/AzureResourceStuff_source/New-AzureAutomationModule.ps1
+++ b/AzureResourceStuff_source/New-AzureAutomationModule.ps1
@@ -129,7 +129,7 @@ function New-AzureAutomationModule {
         }
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/New-AzureAutomationRuntime.ps1
+++ b/AzureResourceStuff_source/New-AzureAutomationRuntime.ps1
@@ -134,7 +134,7 @@
     }
     #endregion checks
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/New-AzureAutomationRuntimeModule.ps1
+++ b/AzureResourceStuff_source/New-AzureAutomationRuntimeModule.ps1
@@ -107,7 +107,7 @@ function New-AzureAutomationRuntimeModule {
         }
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Remove-AzureAutomationRuntime.ps1
+++ b/AzureResourceStuff_source/Remove-AzureAutomationRuntime.ps1
@@ -50,7 +50,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Remove-AzureAutomationRuntimeModule.ps1
+++ b/AzureResourceStuff_source/Remove-AzureAutomationRuntimeModule.ps1
@@ -56,7 +56,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Set-AutomationVariable2.ps1
+++ b/AzureResourceStuff_source/Set-AutomationVariable2.ps1
@@ -39,7 +39,7 @@
         $value
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "Authentication needed. Please call 'Connect-AzAccount -Identity'."
     }
 

--- a/AzureResourceStuff_source/Set-AzureAutomationRunbookRuntime.ps1
+++ b/AzureResourceStuff_source/Set-AzureAutomationRunbookRuntime.ps1
@@ -45,7 +45,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Set-AzureAutomationRuntimeDefaultModule.ps1
+++ b/AzureResourceStuff_source/Set-AzureAutomationRuntimeDefaultModule.ps1
@@ -103,7 +103,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Set-AzureAutomationRuntimeDescription.ps1
+++ b/AzureResourceStuff_source/Set-AzureAutomationRuntimeDescription.ps1
@@ -55,7 +55,7 @@
         [hashtable] $header
     )
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Update-AzureAutomationModule.ps1
+++ b/AzureResourceStuff_source/Update-AzureAutomationModule.ps1
@@ -26,7 +26,7 @@ function Update-AzureAutomationModule {
         throw "Choose allModule or allCustomModule"
     }
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/AzureResourceStuff_source/Update-AzureAutomationRunbookModule.ps1
+++ b/AzureResourceStuff_source/Update-AzureAutomationRunbookModule.ps1
@@ -93,7 +93,7 @@
         throw "Choose moduleName or allCustomModule"
     }
 
-    if (!(Get-Command 'Get-AzAccessToken' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
+    if (!(Get-Command 'Get-AzAccessToken -AsSecureString' -ErrorAction silentlycontinue) -or !($azAccessToken = Get-AzAccessToken -AsSecureString -ErrorAction SilentlyContinue) -or $azAccessToken.ExpiresOn -lt [datetime]::now) {
         throw "$($MyInvocation.MyCommand): Authentication needed. Please call Connect-AzAccount."
     }
 

--- a/M365DefenderStuff/M365DefenderStuff.psm1
+++ b/M365DefenderStuff/M365DefenderStuff.psm1
@@ -723,12 +723,12 @@ function New-M365DefenderAuthHeader {
     if ($identity) {
         # connecting using managed identity
 
-        if (!(Get-Command "Get-AzAccessToken" -ea SilentlyContinue)) {
-            throw "'Get-AzAccessToken' command is missing (module Az.Accounts). Unable to continue"
+        if (!(Get-Command "Get-AzAccessToken -AsSecureString" -ea SilentlyContinue)) {
+            throw "'Get-AzAccessToken -AsSecureString' command is missing (module Az.Accounts). Unable to continue"
         }
 
         $sourceAppIdUri = 'https://api.securitycenter.microsoft.com/.default'
-        $response = Get-AzAccessToken -ResourceUri $sourceAppIdUri
+        $response = Get-AzAccessToken -AsSecureString -ResourceUri $sourceAppIdUri
         $token = $response.token
 
         if (!$token) {
@@ -751,7 +751,7 @@ function New-M365DefenderAuthHeader {
             $token = $authResponse.access_token
         } else {
             # connecting using existing Azure session
-            $AccessToken = Get-AzAccessToken -ResourceUri 'https://api.securitycenter.microsoft.com' -ErrorAction Stop
+            $AccessToken = Get-AzAccessToken -AsSecureString -ResourceUri 'https://api.securitycenter.microsoft.com' -ErrorAction Stop
             $token = $AccessToken.token
         }
 

--- a/M365DefenderStuff_source/New-M365DefenderAuthHeader.ps1
+++ b/M365DefenderStuff_source/New-M365DefenderAuthHeader.ps1
@@ -73,12 +73,12 @@
     if ($identity) {
         # connecting using managed identity
 
-        if (!(Get-Command "Get-AzAccessToken" -ea SilentlyContinue)) {
-            throw "'Get-AzAccessToken' command is missing (module Az.Accounts). Unable to continue"
+        if (!(Get-Command "Get-AzAccessToken -AsSecureString" -ea SilentlyContinue)) {
+            throw "'Get-AzAccessToken -AsSecureString' command is missing (module Az.Accounts). Unable to continue"
         }
 
         $sourceAppIdUri = 'https://api.securitycenter.microsoft.com/.default'
-        $response = Get-AzAccessToken -ResourceUri $sourceAppIdUri
+        $response = Get-AzAccessToken -AsSecureString -ResourceUri $sourceAppIdUri
         $token = $response.token
 
         if (!$token) {
@@ -101,7 +101,7 @@
             $token = $authResponse.access_token
         } else {
             # connecting using existing Azure session
-            $AccessToken = Get-AzAccessToken -ResourceUri 'https://api.securitycenter.microsoft.com' -ErrorAction Stop
+            $AccessToken = Get-AzAccessToken -AsSecureString -ResourceUri 'https://api.securitycenter.microsoft.com' -ErrorAction Stop
             $token = $AccessToken.token
         }
 

--- a/MSGraphStuff/MSGraphStuff.psm1
+++ b/MSGraphStuff/MSGraphStuff.psm1
@@ -981,7 +981,7 @@ function New-GraphAPIAuthHeader {
 
         try {
             # test if connection already exists
-            $azConnectionToken = Get-AzAccessToken -ResourceTypeName MSGraph -ea Stop
+            $azConnectionToken = Get-AzAccessToken -AsSecureString -ResourceTypeName MSGraph -ea Stop
 
             # use AZ connection
 

--- a/MSGraphStuff_source/New-GraphAPIAuthHeader.ps1
+++ b/MSGraphStuff_source/New-GraphAPIAuthHeader.ps1
@@ -241,7 +241,7 @@ function New-GraphAPIAuthHeader {
 
         try {
             # test if connection already exists
-            $azConnectionToken = Get-AzAccessToken -ResourceTypeName MSGraph -ea Stop
+            $azConnectionToken = Get-AzAccessToken -AsSecureString -ResourceTypeName MSGraph -ea Stop
 
             # use AZ connection
 


### PR DESCRIPTION
This fixes all occurances of Get-AZAccessToken to account for the breaking changes with the next major update.

"The Token property of the output type will be changed from String to SecureString. Add the [-AsSecureString] switch to avoid the impact of this upcoming breaking change."

https://learn.microsoft.com/en-us/powershell/azure/upcoming-breaking-changes?view=azps-12.2.0#azaccounts